### PR TITLE
Removed testblock_8s from atf_test_app_publish_rate...

### DIFF
--- a/atf_test_app_publish_rate/config/test_configs/test1.yaml
+++ b/atf_test_app_publish_rate/config/test_configs/test1.yaml
@@ -11,5 +11,7 @@ testblock_5s:
     - topic: /topic3
       groundtruth: 33
       groundtruth_epsilon: 5
-testblock_8s:
-  publish_rate: []
+#testblock_8s:
+#  - topic: /topic3
+#  groundtruth: 33
+#  groundtruth_epsilon: 5

--- a/atf_test_app_publish_rate/config/test_configs/test2.yaml
+++ b/atf_test_app_publish_rate/config/test_configs/test2.yaml
@@ -5,5 +5,6 @@ testblock_3s:
 testblock_5s:
   publish_rate:
     - topic: /topic3
-testblock_8s:
-  publish_rate: []
+#testblock_8s:
+#  publish_rate:
+#    - topic: /topic3

--- a/atf_test_app_publish_rate/scripts/application.py
+++ b/atf_test_app_publish_rate/scripts/application.py
@@ -13,7 +13,7 @@ class Application:
 
     def execute(self):
 
-        self.atf.start("testblock_8s")
+        #self.atf.start("testblock_8s")
         self.atf.start("testblock_3s")
 
         rospy.sleep(3)


### PR DESCRIPTION
...since it was failing in Travis:

```
[atf_test_app_publish_rate.rosunit-analysing_ts0_c0_r0_e0_0/test_Analysing][ERROR]
no valid metric configuration for metric 'publish_rate' in testblock 'testblock_8s'
```